### PR TITLE
Update Application.mk

### DIFF
--- a/Audio_Engine/eclipse_libjamesdsp_free_bp/jni/Application.mk
+++ b/Audio_Engine/eclipse_libjamesdsp_free_bp/jni/Application.mk
@@ -1,3 +1,4 @@
 APP_OPTIM := release
 APP_PLATFORM := android-21
 APP_ABI := armeabi-v7a arm64-v8a x86
+APP_STL := c++_static


### PR DESCRIPTION
This makes the necessity for copying libc++ to the /vendor partition obsolete
https://developer.android.com/ndk/guides/cpp-support.html