### PR TITLE
Fix crash caused by re-use of dangling pointer

### DIFF
--- a/Main/libjamesdsp/jni/jamesdsp/jdsp/Effects/crossfeed.c
+++ b/Main/libjamesdsp/jni/jamesdsp/jdsp/Effects/crossfeed.c
@@ -55,11 +55,13 @@ void CrossfeedEnable(JamesDSPLib *jdsp, char enable)
 		{
 			TwoStageFFTConvolver2x4x2Free(jdsp->advXF.convLong_T_S);
 			free(jdsp->advXF.convLong_T_S);
+			jdsp->advXF.convLong_T_S = NULL;
 		}
 		if (jdsp->advXF.convLong_S_S)
 		{
 			FFTConvolver2x4x2Free(jdsp->advXF.convLong_S_S);
 			free(jdsp->advXF.convLong_S_S);
+			jdsp->advXF.convLong_S_S = NULL;
 		}
 		jdsp->advXF.conv[0] = (FFTConvolver2x4x2 *)malloc(sizeof(FFTConvolver2x4x2));
 		FFTConvolver2x4x2Init(jdsp->advXF.conv[0]);


### PR DESCRIPTION
Original crash report: https://github.com/Audio4Linux/JDSP4Linux/issues/145

A crash occurs when the buffer size changes for the second time.

`FFTConvolver2x4x2Free` crashes because the pointer `jdsp->advXF.convLong_T_S` has not been set to null after being freed and still points to freed memory.
